### PR TITLE
Support any appc ti command, some fixes and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 ![Build Status](https://travis-ci.org/sharpred/grunt-appc-cli.svg?branch=master)
 [![bitHound Score](https://www.bithound.io/github/sharpred/grunt-appc-cli/badges/score.svg)](https://www.bithound.io/github/sharpred/grunt-appc-cli)
+
 # grunt-appc-cli
+
 > Grunt plugin for Appcelerator Platform CLI tools
 
 ## Getting Started
-This plugin requires Grunt
+
+This plugin requires Grunt.
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -18,21 +21,22 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 grunt.loadNpmTasks('grunt-appc-cli');
 ```
 
-## The "appc_cli" task
+## The "appc-cli" task
 
 ### Overview
-In your project's Gruntfile, add a section named `appc_cli` to the data object passed into `grunt.initConfig()`.
+
+In your project's Gruntfile, add a section named `appc-cli` to the data object passed into `grunt.initConfig()`.
 
 ```js
 grunt.initConfig({
-  appc_cli: {
-    options: {
-      // Task-specific options go here.
-    },
-    your_target: {
-      // Target-specific file lists and/or options go here.
-    },
-  },
+    "appc-cli": {
+        options: {
+            // Task-specific options go here.
+        },
+        your_target: {
+            // Target-specific file lists and/or options go here.
+        }
+    }
 });
 ```
 
@@ -57,20 +61,20 @@ In this example, `appc ti build` option is used to run your app in the iOS simul
 
 ```js
 grunt.initConfig({
-  'appc_cli': {
+  "appc-cli": {
     'options': {},
-    'simulator' : {
-                "command" : "ti",
-                "subcommand" : "build",
-                "options" : {
-                    "log-level" : "info",
-                    "platform" : "ios",
-                    "project-dir" : ".",
-                    "target" : "simulator"
-                },
-                "args" : ['--no-banner', "--no-progress-bars", "--no-prompt" ,"--liveview"]
+        'simulator' : {
+            "command" : "ti",
+            "subcommand" : "build",
+            "options" : {
+                "log-level" : "info",
+                "platform" : "ios",
+                "project-dir" : ".",
+                "target" : "simulator"
             },
-  },
+            "args" : ['--no-banner', "--no-progress-bars", "--no-prompt" ,"--liveview"]
+        },
+    },
 });
 ```
 
@@ -80,20 +84,36 @@ In this example, `appc run` option is used to run your app in the iOS simulator 
 
 ```js
 grunt.initConfig({
-  'appc_cli': {
-    'options': {},
-    'simulator': {
-           "command": "run",
-           "args": ["-p", "ios", "-C", "E1406EC4-2BE2-4DFB-BC7C-38473815E862", "--liveview"]
-            },
-  },
+    "appc-cli": {
+        'options': {},
+        'simulator': {
+            "command": "run",
+            "args": ["-p", "ios", "-C", "E1406EC4-2BE2-4DFB-BC7C-38473815E862", "--liveview"]
+        }
+    }
 });
 ```
 
+#### Clean
 
+You could also have for example a `clean` target which would run `appc ti clean`:
+
+```js
+grunt.initConfig({
+    "appc-cli": {
+        "options": {},
+        "clean": {
+            "command": "ti",
+            "subcommand": "clean"
+        }
+    }
+});
+```
 
 ## Contributing
+
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+
 1.0.0 Initial release 30/10/15

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": ">= 0.11.3",
-    "grunt-contrib-clean": ">= 0.7.0",
-    "grunt-contrib-nodeunit": ">= 0.4.1",
     "grunt": ">= 0.4.5",
-    "grunt-env": "~0.4.4"
+    "grunt-contrib-clean": ">= 0.7.0",
+    "grunt-contrib-jshint": ">= 0.11.3",
+    "grunt-contrib-nodeunit": ">= 0.4.1",
+    "grunt-env": "~0.4.4",
+    "lodash": "^4.17.4"
   },
   "peerDependencies": {
     "grunt": ">= 0.4.5"

--- a/tasks/appc-cli.js
+++ b/tasks/appc-cli.js
@@ -16,17 +16,16 @@ module.exports = function(grunt) {
             target = this.target;
         switch(command) {
             case "run":
-            grunt.task.run("run:"+target);
-            break;
+                grunt.task.run("run:"+target);
+                break;
             case "ti":
-            grunt.task.run("ti:"+subcommand+":"+target);
-            break;
+                grunt.task.run("ti:"+subcommand+":"+target);
+                break;
             case "whoami":
-            grunt.task.run("whoami");
-            break;
+                grunt.task.run("whoami");
+                break;
             default:
-            grunt.log.ok(command +" using "+subcommand + " not implemented.  Fork git@github.com:sharpred/grunt-appc-cli.git and submit a pull request!");
-            break;
+                grunt.log.ok(command + (subcommand ? " using " + subcommand : "") + " not implemented.  Fork git@github.com:sharpred/grunt-appc-cli.git and submit a pull request!");
         }
     });
 };

--- a/tasks/ti.js
+++ b/tasks/ti.js
@@ -28,41 +28,36 @@ module.exports = function(grunt) {
             params = ['ti', command],
             settings = appcSettings[job];
 
-        switch(command) {
-            case 'build':
-                var buildArgs = [];
-                _.each(settings.options, function(obj, val) {
-                    params.push("--"+val + "=" + obj);
-                });
-                _.extend(buildArgs, params);
-                settings.args.forEach(function(item){
-                    buildArgs.push(item);
-                });
-
-                task = spawn('appc', buildArgs, {
-                    'cwd' : cwd
-                });
-
-                task.stdout.on('data', function(data) {
-                    if(data.indexOf("Project built successfully") !== -1) {
-                        done(true);
-                    }
-                    grunt.log.ok(data);
-                });
-
-                task.stderr.on('error', function(data) {
-                    grunt.log.error("ti.js " + data);
-                    done(false);
-                });
-
-                task.stdout.on('close', function(code) {
-                    done(true);
-                });
-
-                break;
-            default:
-                grunt.log.ok(this.target + " not implemented.  Fork git@github.com:sharpred/grunt-appc-cli.git and submit a pull request!");
+        var buildArgs = [];
+        _.each(settings.options, function(obj, val) {
+            params.push("--"+val + "=" + obj);
+        });
+        _.extend(buildArgs, params);
+        if (settings.args) {
+            settings.args.forEach(function(item){
+                buildArgs.push(item);
+            });
         }
+
+        task = spawn('appc', buildArgs, {
+            'cwd' : cwd
+        });
+
+        task.stdout.on('data', function(data) {
+            if(data.indexOf("Project built successfully") !== -1) {
+                done(true);
+            }
+            grunt.log.ok(data);
+        });
+
+        task.stderr.on('error', function(data) {
+            grunt.log.error("ti.js " + data);
+            done(false);
+        });
+
+        task.stdout.on('close', function(code) {
+            done(true);
+        });
 
     });
 };

--- a/tasks/whoami.js
+++ b/tasks/whoami.js
@@ -36,6 +36,5 @@ module.exports = function(grunt) {
         task.stdout.on('close', function(code) {
             done(true);
         });
-
     });
 };


### PR DESCRIPTION
**Support any appc ti command and fixes**

That switch/case with only "build" didn't make sense as it's already
dynamic to support any subcommand from `appc ti`.
Also fixing an issue when the args array was not give, the forEach would
crash.
This way now I can have:

```javascript
"appc-cli": {
    "options": {},
    "clean": {
        "command": "ti",
        "subcommand": "clean"
    }
}
```

**Update readme.md accordingly**

Exposing how we could have a `clean` target.
We also fixed the typo as `appc_cli` doesn't work while `"appc-cli"` does.