### PR TITLE
Handling appc ti build buffer output in a better way

### DIFF
--- a/tasks/ti.js
+++ b/tasks/ti.js
@@ -50,8 +50,29 @@ module.exports = function(grunt) {
             grunt.log.ok(data);
         });
 
+        task.stderr.on('data', function(data) {
+            var status = data.toString().substr(0, data.toString().indexOf(" "));
+            switch (status) {
+                case "[DEBUG]":
+                    grunt.log.debug(data);
+                    break;
+                case "[INFO]":
+                    grunt.log.ok(data);
+                    break;
+                case "[WARN]":
+                    grunt.log.error(data);
+                    break;
+                case "[ERROR]":
+                    grunt.log.error(data);
+                    done(false);
+                    break;
+                default:
+                    grunt.log.ok(data);
+            }
+        });
+
         task.stderr.on('error', function(data) {
-            grunt.log.error("ti.js " + data);
+            grunt.log.error(data);
             done(false);
         });
 


### PR DESCRIPTION
Very annoying when grunt-appc-cli was not returning the output from the real command properly.
It was failing silently and you couldn't see the error message properly.
We now map every type of output from the real CLI into grunt so we can see what's  wrong.
Also a critical error will make grunt fail an none of the potential tasks you will want to execute after this one will be triggered if this one fails.